### PR TITLE
Spot instance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,9 @@ Fully managed Spot GPU machines for ML development. Infinite power at minimal co
 
 ## Demos
 
-How to spin up a Spot instance and attach an EBS volume (60 sec video)
+How to spin up a Spot instance and attach an EBS volume (90 sec video)
 
-
-Video showing how to use Infinity on-demand instance:
-
-[![Demo](https://img.youtube.com/vi/lXEeteH3-So/0.jpg)](https://www.youtube.com/watch?v=lXEeteH3-So "Infinity Demo")
+[![Demo](https://img.youtube.com/vi/W3K1U-OZm8s/0.jpg)](https://www.youtube.com/watch?v=W3K1U-OZm8s "Infinity Spot Instance")
 
 # Installation
 
@@ -21,19 +18,19 @@ _Note: Infinity requires Python3_
 
 # How to use
 
-Infinity has 3 cli tools for managing different parts of your workflow.
+Infinity has three cli tools for managing different parts of your workflow.
 
 ## infinity
 
-Use the `infinity` cli tool to create, manage and destroy development machines.
+Use the `infinity` cli tool to create and manage ML development machines.
 
-### Create new ML instance
+### Create new Spot instance
 
-To spin up a new spot machine with a Tesla K-80 GPU in your AWS region:
+To spin up a new spot machine with a *Tesla K-80* GPU in your AWS region:
 
     infinity create --spot
 
-If you would like to change the GPU to a Tesla V-100:
+If you would like to change the GPU to a *Tesla V-100*:
 
     infinity create --spot --instance-type p3.2xlarge
 
@@ -189,7 +186,14 @@ With you AWS account, you need to create an IAM account and security credentials
 
     AmazonEC2FullAccess
     AWSCloudFormationFullAccess
+    AmazonSNSFullAccess
+    CloudWatchFullAccess
+
+To run the `infinity-tools` commands successfully, you also need to add these permissions:
+
     ServiceQuotasFullAccess
+    AWSPriceListServiceFullAccess
+
 
 Then save the new user's Access Key ID and Secret Access Key in a newly created credentials file at `~/.aws/credentials`. The format of the file is below:
 
@@ -208,3 +212,7 @@ To setup infinity in the `us-east-2` region, you need to run:
     infinity setup us-east-2 --ssh-public-key-path ~/.ssh/id_rsa.pub --ssh-private-key-path ~/.ssh/id_rsa
 
 Use the SSH key path you created in the previous step. This will spin up a new CloudFormation stack that setups a secure VPC, Subnet and Security Group. You can view the CloudFormation file in the `~/.infinity` directory. You can also use any other cloud formation file in the setup step here. This newly created network will be used to launch infinity machines.
+
+Video showing how to setup Infinity and manage instances:
+
+[![Demo](https://img.youtube.com/vi/lXEeteH3-So/0.jpg)](https://www.youtube.com/watch?v=lXEeteH3-So "Infinity Demo")

--- a/README.md
+++ b/README.md
@@ -1,20 +1,179 @@
 # INFINITY
 
-Machine Learning dev boxes in the cloud. Infinite power on-demand.
+Fully managed Spot GPU machines for ML development. Infinite power at minimal cost.
 
-## Demo
+## Demos
 
-Video showing how to use Infinity:
+How to spin up a Spot instance and attach an EBS volume (60 sec video)
+
+
+Video showing how to use Infinity on-demand instance:
 
 [![Demo](https://img.youtube.com/vi/lXEeteH3-So/0.jpg)](https://www.youtube.com/watch?v=lXEeteH3-So "Infinity Demo")
 
-# Installation and Setup
+# Installation
 
 Infinity is fully a command line tool. To install infinity from GitHub master branch:
 
     pip install git+https://github.com/narenst/infinity.git@v0.1#egg=infinity
 
-_Note: Infinity requires Python3._
+_Note: Infinity requires Python3_
+
+# How to use
+
+Infinity has 3 cli tools for managing different parts of your workflow.
+
+## infinity
+
+Use the `infinity` cli tool to create, manage and destroy development machines.
+
+### Create new ML instance
+
+To spin up a new spot machine with a Tesla K-80 GPU in your AWS region:
+
+    infinity create --spot
+
+If you would like to change the GPU to a Tesla V-100:
+
+    infinity create --spot --instance-type p3.2xlarge
+
+Spot instances can be preempted by AWS if they have high demand for that instance type. You can switch to on-demand instances to avoid preemption.
+
+    infinity create --on-demand --instance-type p2.xlarge
+
+### Manage instance
+
+To view the instances you have created and their IDs:
+
+    $ infinity list
+
+    ID                   NAME              MACHINE TYPE    TYPE       IP      DISK  STATUS
+    -------------------  ----------------  --------------  ---------  ----  ------  --------
+    i-03819f07f644dfd1e  advanced-nlp-dev  p2.xlarge       on-demand            75  stopped
+
+Use the `start` and `stop` commands to turn on and off the machines
+
+    $ infinity start <ID>
+
+    Starting instance now...
+    Waiting for the instance to be up and running...
+    Machine is started
+
+The stop command works only for on-demand instances:
+
+    $ infinity stop <ID>
+
+    Stopping instance now...
+    Waiting for the instance to be stopped...
+    Machine is stopped
+
+For spot instances, you have to destroy the instance to stop it.
+
+    $ infinity destroy <ID>
+
+    Are you sure you want to destroy the machine? This is irrrecoverable. And you have to chosen to delete the root disk. [y/N]: y
+    Destroying instance now...
+    Removing alerts
+
+You can update the specifications of the machine by using the update command
+
+    $ infinity update <ID> --name advanced-nlp-dev --disk --type t3.large --size 100
+
+    Updating instance name to: advanced-nlp-dev...
+    Updating disk size to: 100...
+    Disk is currently in modifying state. It may take a few minutes for the size change to finish
+    Updating instance type to: t3.large...
+
+### SSH and Jupyter Lab
+
+When the instance is running, use the SSH command to login to the machine
+
+    infinity ssh <ID>
+
+The default machine image contains the latest versions of Tensorflow and PyTorch installed using Conda. Use `tmux` to run long running scripts and you can connect back any time to monitor progress.
+
+Use the jupyter command to setup port forwarding for Jupyter interface. You can now access Jupyter running on the Infinity machine with a http://localhost:8888 endpoint
+
+    infinity jupyter <ID>
+
+Note: This does not start jupyter on the infinity machine. You need to do that yourselves using the `infinity ssh` command.
+
+## infinity-volume
+
+Use the `infinity-volume` cli tool manages EBS volumes and attach/detach them to instances.
+
+To create a new volume, you need to specify either the Availability Zone or a reference instance ID, and infinity will use the same Availability Zone as that instance.
+
+    infinity-volume create --reference-instance-id <INSTANCE_ID> --size 200
+
+You can use volumes to store large datasets and attach them to any instance as its secondary volume. This volume is available at `/data` path on the instance.
+
+_Note: you can only attach the volume to instance in the same availability zone._
+
+    $ infinity-volume attach <VOLUME_ID> --instance-id <INSTANCE_ID>
+    Attaching volume to the instance...
+    Volume successfully attached to instance
+
+_Note: You can attach a volume to only one instance at a time. And an instance can have only one secondary volume attached to it._
+
+To detach a volume from its instance:
+
+    $ infinity-volume detach
+    Detaching volume from instance...
+    Volume successfully detached from instance
+
+_Note: You can only detach an instance when it is in stopped state_
+
+## Manage volumes
+
+You can easily manage volumes with these commands:
+
+    infinity-volume list
+    infinity-volume destroy <VOLUME_ID>
+    infinity-volume update <VOLUME_ID> --name cifar-100 --size 100
+
+## infinity-tools
+
+The `infinity-tools` cli has some helpful tools to select the AWS region and instance type for your projects.
+
+### AWS machine quota
+
+AWS has default limits on which EC2 machine types you are allowed to use. And you may need to request a quota increase for some machine types. Ex: the GPU machine type `p2.xlarge` is not available by default. For cases when you need to request quota increase, use the quota command
+
+    infinity-tools quota --instance-type p2.xlarge
+    infinity-tools quota --instance-type p2.xlarge --increase-to 1
+
+This will submit a new quota increase request to Amazon. You should receive an email on the progress of this request. It will take between 30 minutes to 24 hours for the quota increase to be approved.
+
+### AWS spot instance prices
+
+AWS instances are priced differently across different regions. And spot prices change even between availability zones in the same region. You can use the `price` command to see the real-time prices of instances across all AWS regions where that instance is available:
+
+    infinity-tools price --instance-type p2.xlarge
+
+    Getting On-demand prices across regions ...
+    Getting frequency of interruptions for spot instances ...
+    Getting real-time price of Spot instances ...
+    +----------------+---------------------+-------------------------+--------------------+------------------------+
+    | REGION         | AVAILABILITY ZONE   |   ON-DEMAND PRICE (USD) |   SPOT PRICE (USD) |  FREQ OF INTERRUPTION  |
+    |----------------+---------------------+-------------------------+--------------------+------------------------|
+    | ap-south-1     | ap-south-1a         |                   1.718 |             0.5266 |          >20%          |
+    | ap-south-1     | ap-south-1b         |                   1.718 |             0.5989 |          >20%          |
+    |                |                     |                         |                    |                        |
+    | ap-southeast-1 | ap-southeast-1a     |                   1.718 |             0.6016 |          <5%           |
+    | ap-southeast-1 | ap-southeast-1b     |                   1.718 |             0.5154 |          <5%           |
+    |                |                     |                         |                    |                        |
+    | us-west-2      | us-west-2a          |                   0.9   |             0.2885 |         15-20%         |
+    | us-west-2      | us-west-2b          |                   0.9   |             0.2873 |         15-20%         |
+    | us-west-2      | us-west-2c          |                   0.9   |             0.2709 |         15-20%         |
+    |                |                     |                         |                    |                        |
+    +----------------+---------------------+-------------------------+--------------------+------------------------+
+
+This command also shows the frequency of your spot instance getting interrupted (provided by AWS). You can use this to identify the best region to spin up AWS instances.
+
+# Setup Infinity
+
+This section covers how to setup Infinity before running it for the first time.
 
 ## SSH Key
 
@@ -49,40 +208,3 @@ To setup infinity in the `us-east-2` region, you need to run:
     infinity setup us-east-2 --ssh-public-key-path ~/.ssh/id_rsa.pub --ssh-private-key-path ~/.ssh/id_rsa
 
 Use the SSH key path you created in the previous step. This will spin up a new CloudFormation stack that setups a secure VPC, Subnet and Security Group. You can view the CloudFormation file in the `~/.infinity` directory. You can also use any other cloud formation file in the setup step here. This newly created network will be used to launch infinity machines.
-
-# Manage machines
-
-Use infinity commands to create, manage and destroy development machines. The update command can change the machine name, increase disk size and change the machine type.
-
-    infinity list
-    infinity create
-    infinity destroy <ID>
-    infinity update <ID>
-
-Use the start / stop commands to turn on / off the machine.
-
-    infinity stop <ID>
-    infinity start <ID>
-
-## Connect to the machine
-
-Use the SSH command to login to the machine
-
-    infinity ssh <ID>
-
-The default machine image contains the latest versions of Tensorflow and PyTorch installed using Conda. Use `tmux` to run long running scripts and you can connect back any time to monitor progress.
-
-Use the jupyter command to setup port forwarding for Jupyter interface. You can now access Jupyter running on the Infinity machine with a http://localhost:8888 endpoint
-
-    infinity jupyter <ID>
-
-Note: This does not start jupyter on the infinity machine. You need to do that yourselves using the `infinity ssh` command.
-
-# AWS machine quota
-
-AWS has default limits on which EC2 machine types you are allowed to use. And you may need to request a quota increase for some machine types. Ex: the GPU machine type `p2.xlarge` is not available by default. For cases when you need to request quota increase, use the quota command
-
-    infinity quota --instance-type p2.xlarge
-    infinity quota --instance-type p2.xlarge --increase-to 1
-
-This will submit a new quota increase request to Amazon. You should receive an email on the progress of this request. It will take between 30 minutes to 24 hours for the quota increase to be approved.

--- a/infinity/command/create.py
+++ b/infinity/command/create.py
@@ -122,8 +122,7 @@ def create_cloudwatch_alert_for_instance(session, instance_id, topic_arn):
               help="Email address to send notifications to. This is only sent to AWS SNS service")
 @click.option('--instance-type',
               type=str,
-              help="AWS instance type for the machine",
-              default='None')
+              help="AWS instance type for the machine")
 def create(is_spot, notification_email, instance_type):
     """
     Create a new on-demand or spot instance.

--- a/infinity/command/create.py
+++ b/infinity/command/create.py
@@ -92,7 +92,8 @@ def create_cloudwatch_alert_for_instance(session, instance_id, topic_arn):
 
     cloudwatch_client.put_metric_alarm(
         AlarmName=f'uptime-alarm-for-{instance_id}',
-        AlarmDescription=f'Alert when the instance {instance_id} is running for more than 12 hours',
+        AlarmDescription=f'Instance {instance_id} is running without any usage for more than 3 hours. '
+                         f'Stop instance if not using it.',
         ComparisonOperator='LessThanOrEqualToThreshold',
         MetricName='CPUUtilization',
         Namespace='AWS/EC2',
@@ -122,7 +123,10 @@ def create_cloudwatch_alert_for_instance(session, instance_id, topic_arn):
               help="Email address to send notifications to. This is only sent to AWS SNS service")
 def create(is_spot, attach_volume_id, notification_email):
     """
-    Create a new cloud machine with default specs
+    Create a new on-demand or spot instance.
+
+    Secondary EBS volume id if specified will also be attached to the machine.
+    Add a notification email address to get notified when the machine unused and running.
     """
     session = get_session()
     client = session.client('ec2')

--- a/infinity/command/create.py
+++ b/infinity/command/create.py
@@ -2,6 +2,7 @@ import random
 import string
 from time import sleep
 import click
+import os
 from dateutil.parser import parse
 
 from infinity.aws.auth import get_session
@@ -39,7 +40,8 @@ def get_latest_deep_learning_ami():
 
 @click.command()
 @click.option('--spot/--on-demand', 'is_spot', default=False)
-def create(is_spot):
+@click.option('--attach-volume-id', type=str, help="ID of secondary volume to attach")
+def create(is_spot, attach_volume_id):
     """
     Create a new cloud machine with default specs
     """
@@ -73,6 +75,10 @@ def create(is_spot):
     else:
         instance_market_options = {}
 
+    user_data_file_path = os.path.join(os.path.dirname(__file__), 'user_data.sh')
+    with open(user_data_file_path, 'r') as f:
+        user_data = f.read()
+
     response = client.run_instances(
         ImageId=ami,
         InstanceType=instance_type,
@@ -93,6 +99,7 @@ def create(is_spot):
         MaxCount=1,
         MinCount=1,
         InstanceMarketOptions=instance_market_options,
+        UserData=user_data,
         TagSpecifications=[
             {
                 "ResourceType": "instance",

--- a/infinity/command/create.py
+++ b/infinity/command/create.py
@@ -117,16 +117,19 @@ def create_cloudwatch_alert_for_instance(session, instance_id, topic_arn):
 
 @click.command()
 @click.option('--spot/--on-demand', 'is_spot', default=False)
-@click.option('--attach-volume-id', type=str, help="ID of secondary volume to attach")
 @click.option('--notification-email',
               type=str,
               help="Email address to send notifications to. This is only sent to AWS SNS service")
-def create(is_spot, attach_volume_id, notification_email):
+@click.option('--instance-type',
+              type=str,
+              help="AWS instance type for the machine",
+              default='None')
+def create(is_spot, notification_email, instance_type):
     """
     Create a new on-demand or spot instance.
 
-    Secondary EBS volume id if specified will also be attached to the machine.
     Add a notification email address to get notified when the machine unused and running.
+    Any secondary EBS Volume can be attached after the machine is up and running.
     """
     session = get_session()
     client = session.client('ec2')
@@ -145,8 +148,8 @@ def create(is_spot, attach_volume_id, notification_email):
         print(f"No AMI found, please specify the ami to use in the infinity config file: {CONFIG_FILE_PATH}")
         exit(1)
 
-    print(f"Using ami: {ami}")
-    instance_type = infinity_settings['default_aws_instance_type'] or 'p2.xlarge'
+    instance_type = instance_type or infinity_settings['default_aws_instance_type'] or 'p2.xlarge'
+    print(f"Using ami: {ami}, instance type: {instance_type}")
 
     if is_spot:
         instance_market_options = {

--- a/infinity/command/create.py
+++ b/infinity/command/create.py
@@ -117,7 +117,9 @@ def create_cloudwatch_alert_for_instance(session, instance_id, topic_arn):
 @click.command()
 @click.option('--spot/--on-demand', 'is_spot', default=False)
 @click.option('--attach-volume-id', type=str, help="ID of secondary volume to attach")
-@click.option('--notification-email', type=str, help="Email address to send notifications to. This is only sent to AWS SNS service")
+@click.option('--notification-email',
+              type=str,
+              help="Email address to send notifications to. This is only sent to AWS SNS service")
 def create(is_spot, attach_volume_id, notification_email):
     """
     Create a new cloud machine with default specs
@@ -221,6 +223,9 @@ def create(is_spot, attach_volume_id, notification_email):
     )
 
     # Add email address to SNS Queue and setup alert
+    if not notification_email:
+        notification_email = get_infinity_settings().get('notification_email')
+
     if notification_email:
         topic_arn = subscribe_email_to_instance_notifications(session=session,
                                                               notification_email=notification_email)

--- a/infinity/command/create.py
+++ b/infinity/command/create.py
@@ -38,7 +38,8 @@ def get_latest_deep_learning_ami():
 
 
 @click.command()
-def create():
+@click.option('--spot/--on-demand', 'is_spot', default=False)
+def create(is_spot):
     """
     Create a new cloud machine with default specs
     """
@@ -62,6 +63,16 @@ def create():
     print(f"Using ami: {ami}")
     instance_type = infinity_settings['default_aws_instance_type'] or 'p2.xlarge'
 
+    if is_spot:
+        instance_market_options = {
+            'MarketType': 'spot',
+            'SpotOptions': {
+                'SpotInstanceType': 'one-time',
+            }
+        }
+    else:
+        instance_market_options = {}
+
     response = client.run_instances(
         ImageId=ami,
         InstanceType=instance_type,
@@ -81,6 +92,7 @@ def create():
         SubnetId=infinity_settings.get('aws_subnet_id'),
         MaxCount=1,
         MinCount=1,
+        InstanceMarketOptions=instance_market_options,
         TagSpecifications=[
             {
                 "ResourceType": "instance",

--- a/infinity/command/create.py
+++ b/infinity/command/create.py
@@ -96,11 +96,11 @@ def create_cloudwatch_alert_for_instance(session, instance_id, topic_arn):
         ComparisonOperator='LessThanOrEqualToThreshold',
         MetricName='CPUUtilization',
         Namespace='AWS/EC2',
-        EvaluationPeriods=72, #144,
-        Period=300,
+        EvaluationPeriods=36,  # Check for 3 hours
+        Period=300,  # Check every 5 minutes
         Statistic='Average',
-        Threshold=100.0,
-        ActionsEnabled=False,
+        Threshold=0.5,
+        ActionsEnabled=True,
         TreatMissingData='notBreaching',
         Dimensions=[
             {

--- a/infinity/command/destroy.py
+++ b/infinity/command/destroy.py
@@ -38,5 +38,13 @@ def destroy(id, delete_disk):
             ]
         )
 
+        print("Removing alerts")
+        cloudwatch_client = get_session().client('cloudwatch')
+        cloudwatch_client.delete_alarms(
+            AlarmNames=[
+                f'uptime-alarm-for-{id}'
+            ]
+        )
+
         instance.reload()
         print_machine_info([instance])

--- a/infinity/command/destroy.py
+++ b/infinity/command/destroy.py
@@ -9,7 +9,9 @@ from infinity.command.list import print_machine_info
 @click.option('--delete-disk/--no-delete-disk', default=True, help="Skip deleting the root disk")
 def destroy(id, delete_disk):
     """
-    Terminate the cloud machine with the id. This is irrecoverable
+    Terminate and destroy the cloud instance.
+
+    This is irrrecoverable. But you can keep the root disk and attach to another instance later.
     """
     ec2_resource = get_session().resource('ec2')
     instance = ec2_resource.Instance(id)

--- a/infinity/command/jupyter.py
+++ b/infinity/command/jupyter.py
@@ -12,7 +12,11 @@ from infinity.settings import get_infinity_settings
 @click.option('--infinity-machine-port', type=int, default=8888)
 def jupyter(id, print_command_only, local_port, infinity_machine_port):
     """
-    Setup port forwarding for Jupyter Lab
+    Setup port forwarding for Jupyter Lab.
+
+    This will SSH into the instance and forward the infinity-machine-port to the local machine.
+    Gives a secure option to connect to your Jupyter Lab instance. Note: You need to run Jupyter Lab
+    for this command to work.
     """
     ec2_resource = get_session().resource('ec2')
     instance = ec2_resource.Instance(id)

--- a/infinity/command/list.py
+++ b/infinity/command/list.py
@@ -33,11 +33,12 @@ def print_machine_info(instances):
         machine_info.append([instance.id,
                              get_name_from_tags(instance.tags),
                              instance.instance_type,
+                             instance.instance_lifecycle or 'on-demand',
                              instance.public_ip_address,
                              root_volume_size,
                              instance.state['Name']])
 
-    headers = ["ID", "NAME", "MACHINE TYPE", "IP", "DISK", "STATUS"]
+    headers = ["ID", "NAME", "MACHINE TYPE", "TYPE", "IP", "DISK", "STATUS"]
     print(tabulate(machine_info, headers=headers))
 
 

--- a/infinity/command/list.py
+++ b/infinity/command/list.py
@@ -18,7 +18,7 @@ def get_name_from_tags(tags):
 
 def print_machine_info(instances):
     """
-    Print a table with the machine infor
+    Print a table with the machine info
     """
     ec2_resource = get_session().resource('ec2')
     machine_info = []

--- a/infinity/command/list.py
+++ b/infinity/command/list.py
@@ -45,7 +45,10 @@ def print_machine_info(instances):
 @click.command()
 def list():
     """
-    List all the infinity machines
+    List all the infinity instances.
+
+    Useful to see all the instances in one place. The instance must have an AWS tag
+    type=infinity for it to show up in this list.
     """
     instances = get_infinity_instances(session=get_session())
     print_machine_info(instances)

--- a/infinity/command/price.py
+++ b/infinity/command/price.py
@@ -1,0 +1,113 @@
+import sys
+import click
+import boto3
+import requests
+from datetime import datetime
+from tabulate import tabulate
+
+from infinity.aws.auth import get_session
+from infinity.settings import get_infinity_settings
+
+
+progress_counter = 0
+PROGRESS_CHARS = ['|', '/', '-', '\\']
+SPOT_ADVISOR_DATA_URL = 'https://spot-bid-advisor.s3.amazonaws.com/spot-advisor-data.json'
+ONDEMAND_INSTANCE_PRICE_URL = 'http://www.ec2instances.info/instances.json'
+
+
+def print_progress():
+    global progress_counter
+    sys.stdout.write(PROGRESS_CHARS[progress_counter % len(PROGRESS_CHARS)])
+    progress_counter += 1
+    sys.stdout.flush()
+    sys.stdout.write('\r')
+
+
+def get_interruption_frequency_for_instance_type(instance_type):
+    response = requests.get(SPOT_ADVISOR_DATA_URL)
+    data = response.json()
+
+    region_interrupt_map = {}
+    interrupt_percent_reference = {item['index']: item for item in data['ranges']}
+    for region_name in data['spot_advisor']:
+        interrupt_info = data['spot_advisor'][region_name]['Linux'].get(instance_type)
+        if not interrupt_info:
+            continue
+        interrupt_index = interrupt_info['r']
+        region_interrupt_map[region_name] = interrupt_percent_reference[interrupt_index]['label']
+
+    return region_interrupt_map
+
+
+def get_on_demand_instance_pricing(instance_type):
+    response = requests.get(ONDEMAND_INSTANCE_PRICE_URL)
+    data = response.json()
+
+    region_on_demand_price_map = {}
+    for item in data:
+        if item['instance_type'] == instance_type:
+            for region_name in item['pricing']:
+                on_demand_price = item['pricing'][region_name].get('linux')
+                if on_demand_price:
+                    region_on_demand_price_map[region_name] = on_demand_price.get('ondemand')
+
+    return region_on_demand_price_map
+
+
+@click.command()
+@click.option('--instance-type', required=True, type=str)
+def price(instance_type):
+    """
+    Show the price of the instance type across regions
+    """
+    client = get_session().client('ec2')
+
+    response = client.describe_regions()
+    regions = [item['RegionName'] for item in response['Regions']]
+    regions.sort()
+
+    print("Getting On-demand prices across regions ...")
+    region_on_demand_price = get_on_demand_instance_pricing(instance_type)
+    print("Getting frequency of interruptions for spot instances ...")
+    interruption_frequency = get_interruption_frequency_for_instance_type(instance_type)
+    print("Getting real-time price of Spot instances ...")
+
+    spot_price_table = []
+    for region in regions:
+        print_progress()
+        session = boto3.Session(region_name=region, profile_name=get_infinity_settings()['aws_profile_name'])
+        client = session.client('ec2')
+
+        response = client.describe_availability_zones()
+        azs = [item['ZoneName'] for item in response['AvailabilityZones']]
+
+        spot_price_entries = []
+        for az in azs:
+            print_progress()
+            response = client.describe_spot_price_history(
+                InstanceTypes=[instance_type],
+                MaxResults=5,
+                StartTime=datetime.utcnow(),
+                EndTime=datetime.utcnow(),
+                AvailabilityZone=az,
+                ProductDescriptions=[
+                    "Linux/UNIX",
+                ]
+            )
+            spot_price_history = response['SpotPriceHistory']
+            if not spot_price_history:
+                continue
+
+            spot_price = spot_price_history[0]['SpotPrice']
+            on_demand_price = region_on_demand_price.get(region, 'N/A')
+            interrupt_freq = interruption_frequency.get(region, 'N/A')
+            spot_price_entries.append([region, az, on_demand_price, spot_price, interrupt_freq])
+
+        if spot_price_entries:
+            spot_price_table = spot_price_table + spot_price_entries + ['']
+
+    table_header = ['REGION', 'AVAILABILITY ZONE', 'ON-DEMAND PRICE (USD)', 'SPOT PRICE (USD)', 'FREQ OF INTERRUPTION']
+    print(tabulate(spot_price_table,
+                   headers=table_header,
+                   tablefmt='psql',
+                   colalign=['left', 'left', 'decimal', 'decimal', 'center']))

--- a/infinity/command/price.py
+++ b/infinity/command/price.py
@@ -59,6 +59,7 @@ def get_on_demand_instance_pricing(instance_type):
 def price(instance_type):
     """
     Show the price of the instance type across regions
+    Includes both on-demand and spot instances
     """
     client = get_session().client('ec2')
 

--- a/infinity/command/price.py
+++ b/infinity/command/price.py
@@ -58,8 +58,7 @@ def get_on_demand_instance_pricing(instance_type):
 @click.option('--instance-type', required=True, type=str)
 def price(instance_type):
     """
-    Show the price of the instance type across regions
-    Includes both on-demand and spot instances
+    Show the on-demand and spot price of the instance across regions
     """
     client = get_session().client('ec2')
 

--- a/infinity/command/price.py
+++ b/infinity/command/price.py
@@ -58,7 +58,11 @@ def get_on_demand_instance_pricing(instance_type):
 @click.option('--instance-type', required=True, type=str)
 def price(instance_type):
     """
-    Show the on-demand and spot price of the instance across regions
+    View the spot and on-demand prices for the instance across all AWS regions.
+
+    This command queries the spot instance price for every region that offers the instance.
+    It also gets the probability that the machine will be preempted. For completeness, it also
+    shows the on-demand price for comparison.
     """
     client = get_session().client('ec2')
 

--- a/infinity/command/quota.py
+++ b/infinity/command/quota.py
@@ -16,7 +16,11 @@ def get_value_for_quota_name(quotas, quota_name):
 @click.option('--increase-to', type=int)
 def quota(instance_type, increase_to):
     """
-    Show the quota limit
+    View and increase quota limit for your account.
+
+    This command shows the current quota limit for the instance type in your account.
+    You will not be able to spin up more than the quota number of instances.
+    To increase the quota limit, you can request AWS with this command as well.
     """
     quota_client = get_session().client('service-quotas')
     quota_paginator_client = quota_client.get_paginator('list_service_quotas')

--- a/infinity/command/setup.py
+++ b/infinity/command/setup.py
@@ -4,7 +4,7 @@ from botocore.exceptions import ClientError
 import os
 from shutil import copyfile
 
-from infinity.settings import (get_infinity_settings, update_infinity_settings, 
+from infinity.settings import (get_infinity_settings, update_infinity_settings,
                                CONFIG_FILE_PATH, CLOUD_FORMATION_FILE_PATH)
 
 
@@ -21,7 +21,10 @@ from infinity.settings import (get_infinity_settings, update_infinity_settings,
 @click.option('--ssh-private-key-path',
               required=True,
               type=click.Path(exists=True, resolve_path=True))
-def setup(region_name, aws_profile, cloud_formation_file, ssh_public_key, ssh_private_key_path):
+@click.option('--notification-email',
+              type=str,
+              help="Email address to send notifications to. This is only sent to AWS SNS service")
+def setup(region_name, aws_profile, cloud_formation_file, ssh_public_key, ssh_private_key_path, notification_email):
     """
     Sets up the required AWS components for running infinity
     """
@@ -42,7 +45,7 @@ def setup(region_name, aws_profile, cloud_formation_file, ssh_public_key, ssh_pr
         if not cloud_formation_file:
             print(f"Using default AWS cloudformation from: {CLOUD_FORMATION_FILE_PATH}")
             if not os.path.exists(CLOUD_FORMATION_FILE_PATH):
-                copyfile(os.path.join(os.path.dirname(__file__), 'infinity_cloudformation.yaml'), 
+                copyfile(os.path.join(os.path.dirname(__file__), 'infinity_cloudformation.yaml'),
                          CLOUD_FORMATION_FILE_PATH)
             cloud_formation_file = CLOUD_FORMATION_FILE_PATH
 
@@ -74,7 +77,6 @@ def setup(region_name, aws_profile, cloud_formation_file, ssh_public_key, ssh_pr
             "aws_profile_name": aws_profile,
             "aws_subnet_id": output_map['InfinitySubnetID'],
             "aws_security_group_id": output_map['InfinitySecurityGroupID'],
-            "ssh_private_key_path": ssh_private_key_path,
         }
 
         update_infinity_settings(settings_update)
@@ -98,5 +100,28 @@ def setup(region_name, aws_profile, cloud_formation_file, ssh_public_key, ssh_pr
         )
         print("SSH Public Key uploaded")
 
-    print("\nHow was your setup experience? "
-          "Please share your feedback here: https://github.com/narenst/infinity/issues/new")
+        settings_update = {
+            "ssh_private_key_path": ssh_private_key_path,
+        }
+
+        update_infinity_settings(settings_update)
+        print(f"Infinity config file is updated with the new key info: {CONFIG_FILE_PATH}")
+
+    # Set notification email
+    if not notification_email:
+        notification_email = click.prompt(
+            'Please enter an email address to send instance notifications from AWS. Press enter to skip this',
+            type=str,
+            default=None,
+        )
+
+    if notification_email:
+        update_infinity_settings(
+            {
+                "notification_email": notification_email
+            }
+        )
+        print(f"Infinity config file is updated with the notification email: {CONFIG_FILE_PATH}")
+
+    print("\nHow was your setup experience? Please share your feedback here: "
+          "https://github.com/narenst/infinity/issues/new")

--- a/infinity/command/setup.py
+++ b/infinity/command/setup.py
@@ -26,7 +26,7 @@ from infinity.settings import (get_infinity_settings, update_infinity_settings,
               help="Email address to send notifications to. This is only sent to AWS SNS service")
 def setup(region_name, aws_profile, cloud_formation_file, ssh_public_key, ssh_private_key_path, notification_email):
     """
-    Sets up the required AWS components for running infinity (Run this first time)
+    Sets up infinity before first run.
 
     Before you run Infinity for the first time, you need to run this command. It creates a
     CloudFormation stack. And uploads a SSH key to AWS to connect to the instances

--- a/infinity/command/setup.py
+++ b/infinity/command/setup.py
@@ -26,7 +26,11 @@ from infinity.settings import (get_infinity_settings, update_infinity_settings,
               help="Email address to send notifications to. This is only sent to AWS SNS service")
 def setup(region_name, aws_profile, cloud_formation_file, ssh_public_key, ssh_private_key_path, notification_email):
     """
-    Sets up the required AWS components for running infinity
+    Sets up the required AWS components for running infinity (Run this first time)
+
+    Before you run Infinity for the first time, you need to run this command. It creates a
+    CloudFormation stack. And uploads a SSH key to AWS to connect to the instances
+    you will create. Infinity config is stored in the config file stored at ~/.infinity/settings.yaml.
     """
     session = boto3.Session(region_name=region_name,
                             profile_name=aws_profile)

--- a/infinity/command/ssh.py
+++ b/infinity/command/ssh.py
@@ -10,7 +10,10 @@ from infinity.settings import get_infinity_settings
 @click.option('--print-command-only/--no-print-command-only', default=False)
 def ssh(id, print_command_only):
     """
-    SSH into the infinity machine
+    SSH into the infinity machine.
+
+    This command uses the private key configured in the settings file (~/.infinity/settings.yaml)
+    to connect.
     """
     ec2_resource = get_session().resource('ec2')
     instance = ec2_resource.Instance(id)

--- a/infinity/command/start.py
+++ b/infinity/command/start.py
@@ -9,7 +9,7 @@ from infinity.command.list import print_machine_info
 @click.argument('id')
 def start(id):
     """
-    Start the cloud machine with the id
+    Start the cloud instance.
     """
     session = get_session()
     instance = get_specific_instance(session=session, id=id)

--- a/infinity/command/stop.py
+++ b/infinity/command/stop.py
@@ -9,7 +9,7 @@ from infinity.command.list import print_machine_info
 @click.argument('id')
 def stop(id):
     """
-    Stop the cloud machine with the id
+    Stop the cloud instance.
     """
     session = get_session()
     instance = get_specific_instance(session=session, id=id)

--- a/infinity/command/teardown.py
+++ b/infinity/command/teardown.py
@@ -8,7 +8,10 @@ from infinity.settings import get_infinity_settings
 @click.command()
 def teardown():
     """
-    Deletes all the AWS components created by Infinity
+    Deletes all the AWS components created by infinity setup.
+
+    This is irrecoverable. It will remove the Cloudformation Stack created
+    by the setup command. This is the reverse of setup command.
     """
     infinity_settings = get_infinity_settings()
 

--- a/infinity/command/update.py
+++ b/infinity/command/update.py
@@ -6,12 +6,15 @@ from infinity.command.list import print_machine_info
 
 @click.command()
 @click.argument('id')
-@click.option('--size', type=int, help="Increase the disk size (in GBs)")
+@click.option('--size', type=int, help="Increase the root disk size (in GBs)")
 @click.option('--type', 'instance_type', help="Switch the AWS instance type. Ex: p2.xlarge, t3.large")
 @click.option('--name', help='Set the name of the machine')
 def update(id, size, instance_type, name):
     """
-    Update instance specifications
+    Update instance specifications.
+
+    The instance type can be updated only when the instance is running.
+    Other parameters can be updated in a running instance.
     """
     session = get_session()
     ec2_resource = session.resource('ec2')

--- a/infinity/command/user_data.sh
+++ b/infinity/command/user_data.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+cat > /etc/load_volume.sh << 'ENDOFFILE'
+#!/bin/bash
+
+# Wait until device is available
+i=0
+until [ -e /dev/nvme1n1 ]
+do
+  echo "Waiting for device"
+  sleep 10
+
+  i=$(($i+1))
+  if [ "$i" -eq 6 ]
+  then
+    echo "Device is not available, exiting without mouting volume"
+    exit 0
+  fi
+done
+
+echo "Device is available"
+
+# Format /dev/xvdh if it does not contain a partition yet
+if [ "$(file -b -s /dev/nvme1n1)" == "data" ]; then
+  echo "New volume, formatting the disk"
+  mkfs -t xfs /dev/nvme1n1
+fi
+
+# Create mount point
+mkdir -p /data
+
+# Check if disk is already mounted
+if ! mountpoint -q /data
+then
+  mount /dev/nvme1n1 /data
+  echo "Mounting the disk"
+fi
+
+# Set permissions
+chmod a+rwx /data/
+echo "Permission set"
+
+echo "Done"
+ENDOFFILE
+
+chmod +x /etc/load_volume.sh
+
+# Update rc.local file
+sed -i -e '$i /etc/load_volume.sh\n' /etc/rc.local

--- a/infinity/command/volume/__init__.py
+++ b/infinity/command/volume/__init__.py
@@ -1,0 +1,9 @@
+import click
+
+
+@click.group()
+def volume():
+    """
+    Subcommand for managing EBS volumes
+    """
+    pass

--- a/infinity/command/volume/attach.py
+++ b/infinity/command/volume/attach.py
@@ -1,0 +1,64 @@
+import click
+import os
+
+from infinity.aws.auth import get_session
+from infinity.command.volume import volume
+from infinity.command.volume.list import print_volume_info
+from infinity.settings import get_infinity_settings
+
+
+@volume.command()
+@click.argument('volume-id')
+@click.option('--instance-id', required=True, type=str, help="ID of instance to attach to")
+def attach(volume_id, instance_id):
+    """
+    Attach the volume to the instance
+    """
+    ec2_resource = get_session().resource('ec2')
+
+    # Check if volume is already attached to a device
+    volume = ec2_resource.Volume(volume_id)
+    if volume.attachments:
+        raise Exception("Volume is currently already attached to an instance")
+
+    instance = ec2_resource.Instance(instance_id)
+
+    # Check if instance already has another secondary disk
+    for attachment in instance.block_device_mappings:
+        if attachment['DeviceName'] == '/dev/sdh':
+            raise Exception(f"Instance {instance_id} already has a secondary volume attached to it")
+
+    # Check if instance is stopped
+    if not instance.state['Name'] in ['stopped', 'running']:
+        raise Exception(f"Volume can be mounted only to a stopped or running instance. Current state: {instance.state['Name']}")
+
+    print("Attaching volume to the instance...")
+
+    volume.attach_to_instance(
+        Device='/dev/sdh',
+        InstanceId=instance_id,
+    )
+
+    ec2_client = get_session().client('ec2')
+    waiter = ec2_client.get_waiter('volume_in_use')
+    waiter.wait(VolumeIds=[volume_id])
+
+    print("Volume successfully attached to instance")
+
+    if instance.state['Name'] == 'running':
+        print("Mounting the disk to the running machine at: /data")
+        # Connect to the machine and run /etc/load_volume.sh script
+        ssh_private_key_path = get_infinity_settings().get('ssh_private_key_path')
+
+        # Ignore the KeyChecking since the hosts are trusted
+        ssh_command = f"ssh -oStrictHostKeyChecking=no -i {ssh_private_key_path} ubuntu@{instance.public_ip_address} sudo /etc/load_volume.sh"
+
+        os.environ["PYTHONUNBUFFERED"] = "1"
+        os.system(ssh_command)
+
+    response = ec2_client.describe_volumes(
+        VolumeIds=[
+            volume_id
+        ]
+    )
+    print_volume_info(response['Volumes'])

--- a/infinity/command/volume/attach.py
+++ b/infinity/command/volume/attach.py
@@ -7,6 +7,9 @@ from infinity.command.volume.list import print_volume_info
 from infinity.settings import get_infinity_settings
 
 
+SECONDARY_EBS_DEVICE_NAME = '/dev/sdh'
+
+
 @volume.command()
 @click.argument('volume-id')
 @click.option('--instance-id', required=True, type=str, help="ID of instance to attach to")
@@ -25,7 +28,7 @@ def attach(volume_id, instance_id):
 
     # Check if instance already has another secondary disk
     for attachment in instance.block_device_mappings:
-        if attachment['DeviceName'] == '/dev/sdh':
+        if attachment['DeviceName'] == SECONDARY_EBS_DEVICE_NAME:
             raise Exception(f"Instance {instance_id} already has a secondary volume attached to it")
 
     # Check if instance is stopped
@@ -35,7 +38,7 @@ def attach(volume_id, instance_id):
     print("Attaching volume to the instance...")
 
     volume.attach_to_instance(
-        Device='/dev/sdh',
+        Device=SECONDARY_EBS_DEVICE_NAME,
         InstanceId=instance_id,
     )
 

--- a/infinity/command/volume/attach.py
+++ b/infinity/command/volume/attach.py
@@ -33,7 +33,8 @@ def attach(volume_id, instance_id):
 
     # Check if instance is stopped
     if not instance.state['Name'] in ['stopped', 'running']:
-        raise Exception(f"Volume can be mounted only to a stopped or running instance. Current state: {instance.state['Name']}")
+        raise Exception(f"Volume can be mounted only to a stopped or running instance. "
+                        f"Current state: {instance.state['Name']}")
 
     print("Attaching volume to the instance...")
 
@@ -54,7 +55,8 @@ def attach(volume_id, instance_id):
         ssh_private_key_path = get_infinity_settings().get('ssh_private_key_path')
 
         # Ignore the KeyChecking since the hosts are trusted
-        ssh_command = f"ssh -oStrictHostKeyChecking=no -i {ssh_private_key_path} ubuntu@{instance.public_ip_address} sudo /etc/load_volume.sh"
+        ssh_command = f"ssh -oStrictHostKeyChecking=no -i {ssh_private_key_path} " \
+                      f"ubuntu@{instance.public_ip_address} sudo /etc/load_volume.sh"
 
         os.environ["PYTHONUNBUFFERED"] = "1"
         os.system(ssh_command)

--- a/infinity/command/volume/attach.py
+++ b/infinity/command/volume/attach.py
@@ -34,10 +34,20 @@ def attach(volume_id, instance_id):
         if attachment['DeviceName'] == SECONDARY_EBS_DEVICE_NAME:
             raise Exception(f"Instance {instance_id} already has a secondary volume attached to it")
 
-    # Check if instance is stopped
+    # Check if instance is stopped or running
     if not instance.state['Name'] in ['stopped', 'running']:
         raise Exception(f"Volume can be mounted only to a stopped or running instance. "
                         f"Current state: {instance.state['Name']}")
+
+    # Check if the user data script is finished running
+    ssh_private_key_path = get_infinity_settings().get('ssh_private_key_path')
+    if instance.state['Name'] == 'running':
+        # Ignore the KeyChecking since the hosts are trusted
+        ssh_command = f"ssh -oStrictHostKeyChecking=no -i {ssh_private_key_path} " \
+                      f"ubuntu@{instance.public_ip_address} ls /etc/load_volume.sh"
+        code = os.system(ssh_command)
+        if code != 0:
+            raise Exception(f"Instance does not have the data mount script. Try again after a few seconds")
 
     print("Attaching volume to the instance...")
 
@@ -55,9 +65,6 @@ def attach(volume_id, instance_id):
     if instance.state['Name'] == 'running':
         print("Mounting the disk to the running machine at: /data")
         # Connect to the machine and run /etc/load_volume.sh script
-        ssh_private_key_path = get_infinity_settings().get('ssh_private_key_path')
-
-        # Ignore the KeyChecking since the hosts are trusted
         ssh_command = f"ssh -oStrictHostKeyChecking=no -i {ssh_private_key_path} " \
                       f"ubuntu@{instance.public_ip_address} sudo /etc/load_volume.sh"
 

--- a/infinity/command/volume/attach.py
+++ b/infinity/command/volume/attach.py
@@ -15,7 +15,10 @@ SECONDARY_EBS_DEVICE_NAME = '/dev/sdh'
 @click.option('--instance-id', required=True, type=str, help="ID of instance to attach to")
 def attach(volume_id, instance_id):
     """
-    Attach the volume to the instance
+    Attach the volume as a secondary disk to an instance.
+
+    This command works only when the instance is running or in stopped state. Ensure that the
+    instance does not already have a secondary disk volume attached.
     """
     ec2_resource = get_session().resource('ec2')
 

--- a/infinity/command/volume/create.py
+++ b/infinity/command/volume/create.py
@@ -22,11 +22,6 @@ def create(instance_id, volume_az, size):
     else:
         raise Exception("Specify one of --az or --reference-instance-id")
 
-    # # Ensure the instance does not already have a secondary disk
-    # for block_device in instance.block_device_mappings:
-    #     if block_device['DeviceName'] == '/dev/sdh':
-    #         raise Exception(f"Instance already has a secondary volume attached to it: {block_device['Ebs']['VolumeId']}")
-
     ec2_client = get_session().client('ec2')
     machine_name_suffix = ''.join(random.choice(string.ascii_lowercase) for x in range(10))
 
@@ -56,15 +51,6 @@ def create(instance_id, volume_az, size):
 
     waiter = ec2_client.get_waiter('volume_available')
     waiter.wait(VolumeIds=[volume_id])
-
-    # response = ec2_client.attach_volume(
-    #     Device='/dev/sdh',
-    #     InstanceId=instance_id,
-    #     VolumeId=volume_id,
-    # )
-
-    # waiter = ec2_client.get_waiter('volume_in_use')
-    # waiter.wait(VolumeIds=[volume_id])
 
     # print(f"Successfully attached the new volume {volume_id} to instance {instance_id}")
     response = ec2_client.describe_volumes(

--- a/infinity/command/volume/create.py
+++ b/infinity/command/volume/create.py
@@ -1,0 +1,75 @@
+import click
+import random
+import string
+
+from infinity.aws.auth import get_session
+from infinity.command.volume import volume
+from infinity.command.volume.list import print_volume_info
+
+
+@volume.command()
+@click.option('--reference-instance-id', 'instance_id', type=str, help="ID of reference instance for the volume")
+@click.option('--az', 'volume_az', type=str, help="Availability zone")
+@click.option('--size', default=100, type=int, help='Disk size in GBs')
+def create(instance_id, volume_az, size):
+    ec2_resource = get_session().resource('ec2')
+
+    if instance_id:
+        instance = ec2_resource.Instance(instance_id)
+        az = instance.placement['AvailabilityZone']
+    elif volume_az:
+        az = volume_az
+    else:
+        raise Exception("Specify one of --az or --reference-instance-id")
+
+    # # Ensure the instance does not already have a secondary disk
+    # for block_device in instance.block_device_mappings:
+    #     if block_device['DeviceName'] == '/dev/sdh':
+    #         raise Exception(f"Instance already has a secondary volume attached to it: {block_device['Ebs']['VolumeId']}")
+
+    ec2_client = get_session().client('ec2')
+    machine_name_suffix = ''.join(random.choice(string.ascii_lowercase) for x in range(10))
+
+    response = ec2_client.create_volume(
+        AvailabilityZone=az,
+        VolumeType='gp2',
+        Size=size,
+        TagSpecifications=[
+            {
+                "ResourceType": "volume",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": f"infinity-{machine_name_suffix}"
+                    },
+                    {
+                        "Key": "type",
+                        "Value": "infinity"
+                    }
+                ]
+            }
+        ]
+    )
+
+    volume_id = response['VolumeId']
+    print(f"Created new volume with id: {volume_id}")
+
+    waiter = ec2_client.get_waiter('volume_available')
+    waiter.wait(VolumeIds=[volume_id])
+
+    # response = ec2_client.attach_volume(
+    #     Device='/dev/sdh',
+    #     InstanceId=instance_id,
+    #     VolumeId=volume_id,
+    # )
+
+    # waiter = ec2_client.get_waiter('volume_in_use')
+    # waiter.wait(VolumeIds=[volume_id])
+
+    # print(f"Successfully attached the new volume {volume_id} to instance {instance_id}")
+    response = ec2_client.describe_volumes(
+        VolumeIds=[
+            volume_id
+        ]
+    )
+    print_volume_info(response['Volumes'])

--- a/infinity/command/volume/create.py
+++ b/infinity/command/volume/create.py
@@ -12,6 +12,13 @@ from infinity.command.volume.list import print_volume_info
 @click.option('--az', 'volume_az', type=str, help="Availability zone")
 @click.option('--size', default=100, type=int, help='Disk size in GBs')
 def create(instance_id, volume_az, size):
+    """
+    Create new EBS volume.
+
+    Requires a reference EC2 instance id or Availability Zone info. This volume is persisted even after
+    the EC2 instance is destroyed. Note: AWS will charge you for EBS volumes whether they are attached
+    to an instance or not.
+    """
     ec2_resource = get_session().resource('ec2')
 
     if instance_id:

--- a/infinity/command/volume/destroy.py
+++ b/infinity/command/volume/destroy.py
@@ -1,0 +1,28 @@
+import click
+
+from infinity.aws.auth import get_session
+from infinity.command.volume import volume
+
+
+@volume.command()
+@click.argument('volume-id')
+def destroy(volume_id):
+    """
+    Destroy the volume
+    """
+    ec2_resource = get_session().resource('ec2')
+    volume = ec2_resource.Volume(volume_id)
+    if volume.attachments:
+        raise Exception(f"Volume is currently not attached to instance: {volume.attachments[0]['InstanceId']}")
+
+    if click.confirm("\nAre you sure you want to destroy the volume? This is irrrecoverable."):
+
+        print("Destroying volume ...")
+        volume.delete()
+
+        print("Destroy successful, it may take a few seconds to fully destroy the volume ...")
+        ec2_client = get_session().client('ec2')
+        waiter = ec2_client.get_waiter('volume_deleted')
+        waiter.wait(VolumeIds=[volume_id])
+
+        print("Destroy complete")

--- a/infinity/command/volume/destroy.py
+++ b/infinity/command/volume/destroy.py
@@ -8,7 +8,10 @@ from infinity.command.volume import volume
 @click.argument('volume-id')
 def destroy(volume_id):
     """
-    Destroy the volume
+    Destroy the volume.
+
+    Can only be run when it is not attached to any instance. The disk is
+    not recoverable after destroying.
     """
     ec2_resource = get_session().resource('ec2')
     volume = ec2_resource.Volume(volume_id)

--- a/infinity/command/volume/detach.py
+++ b/infinity/command/volume/detach.py
@@ -1,0 +1,42 @@
+import click
+
+from infinity.aws.auth import get_session
+from infinity.command.volume import volume
+from infinity.command.volume.list import print_volume_info
+
+
+@volume.command()
+@click.argument('volume-id')
+def detach(volume_id):
+    """
+    Detach the volume from the instance
+    """
+    ec2_resource = get_session().resource('ec2')
+    volume = ec2_resource.Volume(volume_id)
+    if not volume.attachments:
+        raise Exception("Volume is currently not attached to any instance")
+
+    instance_id = volume.attachments[0]['InstanceId']
+    instance = ec2_resource.Instance(instance_id)
+
+    if not instance.state['Name'] == 'stopped':
+        raise Exception("Cannot unmount disk from a running instance")
+
+    print("Detaching volume from instance...")
+
+    volume.detach_from_instance(
+        InstanceId=instance_id,
+    )
+
+    ec2_client = get_session().client('ec2')
+    waiter = ec2_client.get_waiter('volume_available')
+    waiter.wait(VolumeIds=[volume_id])
+
+    print("Volume successfully detached from instance")
+
+    response = ec2_client.describe_volumes(
+        VolumeIds=[
+            volume_id
+        ]
+    )
+    print_volume_info(response['Volumes'])

--- a/infinity/command/volume/detach.py
+++ b/infinity/command/volume/detach.py
@@ -9,7 +9,9 @@ from infinity.command.volume.list import print_volume_info
 @click.argument('volume-id')
 def detach(volume_id):
     """
-    Detach the volume from the instance
+    Detach the volume from its instance.
+
+    The detached volume can then be attached to any other instance.
     """
     ec2_resource = get_session().resource('ec2')
     volume = ec2_resource.Volume(volume_id)

--- a/infinity/command/volume/list.py
+++ b/infinity/command/volume/list.py
@@ -1,0 +1,49 @@
+from tabulate import tabulate
+
+from infinity.aws.auth import get_session
+from infinity.command.volume import volume
+from infinity.command.list import get_name_from_tags
+
+
+def print_volume_info(volumes):
+    volume_info = []
+    for vol in volumes:
+        attachments = vol['Attachments']
+        if attachments:
+            instance_id = attachments[0]['InstanceId']
+            if attachments[0]['Device'] == '/dev/sda1':
+                disk_type = 'root'
+            else:
+                disk_type = 'secondary'
+        else:
+            instance_id = 'N/A'
+            disk_type = 'N/A'
+
+        volume_info.append(
+            [
+                vol['VolumeId'],
+                get_name_from_tags(vol['Tags']),
+                vol['Size'],
+                vol['State'],
+                vol['AvailabilityZone'],
+                instance_id,
+                disk_type
+            ]
+        )
+
+    headers = ["VOLUME ID", "NAME", "DISK SIZE", "STATUS", "AVAILABILITY ZONE", "ATTACHED INSTANCE ID", "DISK TYPE"]
+    print(tabulate(volume_info, headers=headers))
+
+
+@volume.command()
+def list():
+    ec2_client = get_session().client('ec2')
+    response = ec2_client.describe_volumes(
+        Filters=[
+            {
+                'Name': 'tag:type',
+                'Values': ['infinity']
+            }
+        ]
+    )
+    print_volume_info(response['Volumes'])

--- a/infinity/command/volume/list.py
+++ b/infinity/command/volume/list.py
@@ -37,6 +37,12 @@ def print_volume_info(volumes):
 
 @volume.command()
 def list():
+    """
+    Prints a list of all your volumes.
+
+    Useful to see all the volumes in one place. The volumes must have an AWS tag
+    type=infinity for the volume to show up in this list.
+    """
     ec2_client = get_session().client('ec2')
     response = ec2_client.describe_volumes(
         Filters=[

--- a/infinity/command/volume/update.py
+++ b/infinity/command/volume/update.py
@@ -1,0 +1,37 @@
+import click
+
+from infinity.aws.auth import get_session
+from infinity.command.volume import volume
+
+
+@volume.command()
+@click.argument('volume-id')
+@click.option('--size', type=int, help="Increase the disk size (in GBs)")
+@click.option('--name', help='Set the name of the machine')
+def update(volume_id, size, name):
+    """
+    Update volume specs
+    """
+    ec2_resource = get_session().resource('ec2')
+    ec2_client = get_session().client('ec2')
+    volume = ec2_resource.Volume(volume_id)
+
+    if name:
+        print(f"Updating volume name to: {name}...")
+        volume.create_tags(
+            Tags=[
+                {
+                    "Key": "Name",
+                    "Value": name,
+                }
+            ]
+        )
+
+    if size:
+        print(f"Updating disk size to: {size}...")
+        response = ec2_client.modify_volume(
+            VolumeId=volume_id,
+            Size=size
+        )
+        status = response['VolumeModification']['ModificationState']
+        print(f"Disk is currently in {status} state. It may take a few minutes for the size change to finish")

--- a/infinity/command/volume/update.py
+++ b/infinity/command/volume/update.py
@@ -10,7 +10,9 @@ from infinity.command.volume import volume
 @click.option('--name', help='Set the name of the machine')
 def update(volume_id, size, name):
     """
-    Update volume specs
+    Update the name or size of the volume.
+
+    Ensure that you are only increasing the size of the disk.
     """
     ec2_resource = get_session().resource('ec2')
     ec2_client = get_session().client('ec2')

--- a/infinity/main.py
+++ b/infinity/main.py
@@ -13,17 +13,35 @@ from infinity.command.jupyter import jupyter
 from infinity.command.quota import quota
 from infinity.command.price import price
 
-from infinity.command.volume import volume
-from infinity.command.volume.list import list as volume_list # noqa
-from infinity.command.volume.create import create as volume_create # noqa
-from infinity.command.volume.detach import detach as volume_detach # noqa
-from infinity.command.volume.attach import attach as volume_attach # noqa
-from infinity.command.volume.destroy import destroy as volume_destroy # noqa
-from infinity.command.volume.update import update as volume_update # noqa
+from infinity.command.volume.list import list as volume_list
+from infinity.command.volume.create import create as volume_create
+from infinity.command.volume.detach import detach as volume_detach
+from infinity.command.volume.attach import attach as volume_attach
+from infinity.command.volume.destroy import destroy as volume_destroy
+from infinity.command.volume.update import update as volume_update
 
 
 @click.group()
 def cli():
+    """
+    Infinity commands to manage AWS machines for ML.
+    """
+    pass
+
+
+@click.group()
+def volume():
+    """
+    Infinity cli specifically to manage EBS disk volumes.
+    """
+    pass
+
+
+@click.group()
+def tools():
+    """
+    Special purpose AWS tools
+    """
     pass
 
 
@@ -38,6 +56,15 @@ cli.add_command(setup)
 cli.add_command(teardown)
 cli.add_command(ssh)
 cli.add_command(jupyter)
-cli.add_command(quota)
-cli.add_command(price)
-cli.add_command(volume)
+
+
+volume.add_command(volume_list)
+volume.add_command(volume_create)
+volume.add_command(volume_attach)
+volume.add_command(volume_detach)
+volume.add_command(volume_destroy)
+volume.add_command(volume_update)
+
+
+tools.add_command(quota)
+tools.add_command(price)

--- a/infinity/main.py
+++ b/infinity/main.py
@@ -11,6 +11,7 @@ from infinity.command.teardown import teardown
 from infinity.command.ssh import ssh
 from infinity.command.jupyter import jupyter
 from infinity.command.quota import quota
+from infinity.command.price import price
 
 
 # import ptvsd
@@ -36,3 +37,4 @@ cli.add_command(teardown)
 cli.add_command(ssh)
 cli.add_command(jupyter)
 cli.add_command(quota)
+cli.add_command(price)

--- a/infinity/main.py
+++ b/infinity/main.py
@@ -13,11 +13,13 @@ from infinity.command.jupyter import jupyter
 from infinity.command.quota import quota
 from infinity.command.price import price
 
-
-# import ptvsd
-# print("Waiting for debugger attach")
-# ptvsd.enable_attach(address=('localhost', 5678), redirect_output=True)
-# ptvsd.wait_for_attach()
+from infinity.command.volume import volume
+from infinity.command.volume.list import list as volume_list # noqa
+from infinity.command.volume.create import create as volume_create # noqa
+from infinity.command.volume.detach import detach as volume_detach # noqa
+from infinity.command.volume.attach import attach as volume_attach # noqa
+from infinity.command.volume.destroy import destroy as volume_destroy # noqa
+from infinity.command.volume.update import update as volume_update # noqa
 
 
 @click.group()
@@ -38,3 +40,4 @@ cli.add_command(ssh)
 cli.add_command(jupyter)
 cli.add_command(quota)
 cli.add_command(price)
+cli.add_command(volume)

--- a/infinity/settings.py
+++ b/infinity/settings.py
@@ -3,12 +3,14 @@ import os
 from shutil import copyfile
 
 
-CONFIG_FILE_PATH = os.path.expanduser('~/.infinity/settings.yaml')
+CONFIG_FILE_DIR = os.path.expanduser('~/.infinity')
+CONFIG_FILE_PATH = os.path.join(CONFIG_FILE_DIR, 'settings.yaml')
 CLOUD_FORMATION_FILE_PATH = os.path.expanduser('~/.infinity/infinity_cloudformation.yaml')
 
 
 def get_infinity_settings():
     if not os.path.exists(CONFIG_FILE_PATH):
+        os.makedirs(CONFIG_FILE_DIR, exist_ok=True)
         copyfile(os.path.join(os.path.dirname(__file__), 'settings.yaml'), CONFIG_FILE_PATH)
 
     with open(CONFIG_FILE_PATH, 'r') as config_file:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
     entry_points={
         "console_scripts": [
             "infinity = infinity.main:cli",
+            "infinity-volume = infinity.main:volume",
+            "infinity-tools = infinity.main:tools",
         ],
     },
     tests_require=[


### PR DESCRIPTION
Fixes #2 

- User can now spin up spot instances
- Also has a new command line tool `infinity-volume` to manage EBS volumes and attach it to instances as secondary disk
- Add a new `infinity-tools` command for checking instance prices